### PR TITLE
New arming sequence, implementing hysteresis on throttle

### DIFF
--- a/inc/motor_driver.h
+++ b/inc/motor_driver.h
@@ -22,13 +22,19 @@ typedef enum
 
 /**
  * Describes the indeces corresponding to each motor
+ *
+ *  0  1
+ *   \/
+ *   /\
+ *  3  2
+ *
  */
 typedef enum
 {
   MOTOR_DRIVER_NW = 0, /*!< Northwest motor */
   MOTOR_DRIVER_NE,     /*!< Northeast motor */
-  MOTOR_DRIVER_SW,     /*!< Southwest motor */
   MOTOR_DRIVER_SE,     /*!< Southeast motor */
+  MOTOR_DRIVER_SW,     /*!< Southwest motor */
   MOTOR_DRIVER_MOTORS  /*!< Number of motors being driven */
 } motor_driver_positions_t;
 

--- a/inc/radio_tx_rx.h
+++ b/inc/radio_tx_rx.h
@@ -11,6 +11,11 @@
 #include "hal.h"
 
 /**
+ * Frame length in milliseconds
+ */
+#define RADIO_PPM_LENGTH_MS 20U
+
+/**
  * Radio transceiver states
  */
 typedef enum
@@ -42,7 +47,7 @@ typedef enum
 {
   RADIO_TXRX_ROLL = 0,
   RADIO_TXRX_PITCH,
-  RADIO_TXRX_ALTITUDE,
+  RADIO_TXRX_THROTTLE,
   RADIO_TXRX_YAW,
   RADIO_TXRX_VRA,
   RADIO_TXRX_VRB,
@@ -81,5 +86,11 @@ void radioTxRxStart(radio_tx_rx_handle_t* handle);
  * \param[out] channels - signal values on each channel
  */
 void radioTxRxReadInputs(radio_tx_rx_handle_t* handle, uint32_t channels[RADIO_TXRX_CHANNELS]);
+
+/**
+ * \brief Get the state of the radio transceiver
+ * \param[in] handle - radio transceiver handle
+ */
+radio_tx_rx_state_t radioTxRxGetState(radio_tx_rx_handle_t* handle);
 
 #endif /* RADIO_TX_RX_H */

--- a/src/main_controller.c
+++ b/src/main_controller.c
@@ -18,6 +18,37 @@
 main_ctrl_handle_t MAIN_CTRL;
 
 /**
+ * flight states
+ */
+typedef enum
+{
+  GROUNDED = 0, /*!< multirotor is grounded, pull throttle above threshold to commence flight */
+  FLYING,      /*!< multirotor is flying, pull throttle down to minimum threshold to ground the multirotor */
+  HYSTERESIS_STATES
+} hysteresis_states_t;
+
+/**
+ * hysteresis range definition
+ */
+typedef struct
+{
+  uint32_t min;
+  uint32_t max;
+} hysteresis_range_t;
+
+/**
+ * hysteresis ranges for flight state transitions
+ */
+static hysteresis_range_t hysteresis_ranges[HYSTERESIS_STATES] =
+{
+  /* MIN = 0%, MAX = 25% */
+  { 0U,    2500U }, /* grounded */
+
+  /* MIN = 10%, MAX = 100% */
+  { 1000U, 10000U } /* liftoff */
+};
+
+/**
  * Main Controller Thread.
  * It takes data from the IMU engine and Radio Transceiver modules
  * to determine how to drive the motors.
@@ -27,6 +58,42 @@ THD_FUNCTION(mainControllerThread, arg)
 {
   (void)arg;
 
+  /* keep track of hysteresis state */
+  static hysteresis_states_t flight_state = GROUNDED;
+
+  /**
+   * wait for radio transceiver to read first frame
+   */
+  while(radioTxRxGetState(&RADIO_TXRX) != RADIO_TXRX_ACTIVE) {
+    chThdSleepMilliseconds(5U);
+  }
+
+  /* wait for first frame to be parsed */
+  chThdSleepMilliseconds(RADIO_PPM_LENGTH_MS);
+
+  /**
+   * Arming sequence
+   * make sure throttle is at the bottom position
+   * (or at least less than the throttle threshold when multirotor is grounded)
+   */
+
+  uint32_t throttle_signal = 0U;
+
+  do {
+
+    uint32_t channels[MOTOR_DRIVER_MOTORS] = {0U};
+    radioTxRxReadInputs(&RADIO_TXRX, channels);
+
+    throttle_signal = channels[RADIO_TXRX_THROTTLE];
+
+    chThdSleepMilliseconds(RADIO_PPM_LENGTH_MS);
+
+  } while(throttle_signal >= hysteresis_ranges[flight_state].max);
+
+  /**
+   * Main logic
+   */
+
   while(true)
   {
     uint32_t channels[RADIO_TXRX_CHANNELS] = {0U};
@@ -34,9 +101,24 @@ THD_FUNCTION(mainControllerThread, arg)
 
     radioTxRxReadInputs(&RADIO_TXRX, channels);
 
+    /* hysteresis check */
+    throttle_signal = channels[RADIO_TXRX_THROTTLE];
+
+    if(throttle_signal > hysteresis_ranges[flight_state].max) {
+
+      /* move up next flight state */
+      flight_state++;
+
+    } else if(throttle_signal < hysteresis_ranges[flight_state].min) {
+
+      /* move down previous flight state */
+      flight_state--;
+
+    }
+
     for(size_t i = 0 ; i < MOTOR_DRIVER_MOTORS ; i++) {
 
-      duty_cycles[i] = channels[RADIO_TXRX_ALTITUDE];
+      duty_cycles[i] = (flight_state == FLYING) ? channels[RADIO_TXRX_THROTTLE] : 0U;
 
     }
 

--- a/src/main_controller.c
+++ b/src/main_controller.c
@@ -44,8 +44,8 @@ static hysteresis_range_t hysteresis_ranges[HYSTERESIS_STATES] =
   /* MIN = 0%, MAX = 25% */
   { 0U,    2500U }, /* grounded */
 
-  /* MIN = 10%, MAX = 100% */
-  { 1000U, 10000U } /* liftoff */
+  /* MIN = 15%, MAX = 100% */
+  { 1500U, 10000U } /* liftoff */
 };
 
 /**

--- a/src/radio_tx_rx.c
+++ b/src/radio_tx_rx.c
@@ -181,3 +181,12 @@ void radioTxRxReadInputs(radio_tx_rx_handle_t* handle, uint32_t channels[RADIO_T
   }
 
 }
+
+/**
+ * \brief Get the state of the radio transceiver
+ * \param[in] handle - radio transceiver handle
+ */
+radio_tx_rx_state_t radioTxRxGetState(radio_tx_rx_handle_t* handle)
+{
+  return handle->state;
+}


### PR DESCRIPTION
Changes:
* New arming sequence : on system startup, throttle needs to be on the bottom position
* Implemented hysteresis on throttle : motors only driven once throttle has reached threshold value